### PR TITLE
Allow numeric uid and gid

### DIFF
--- a/pkg/commands/copy.go
+++ b/pkg/commands/copy.go
@@ -38,13 +38,6 @@ type CopyCommand struct {
 	snapshotFiles []string
 }
 
-func (c *CopyCommand) RequiresUnpackedFS() bool {
-    // We want to unpack the root filesystem if the copy command is going
-    // to require resolving UIDs or GIDs that might have been defined
-    // in the base image
-    return c.cmd.Chown != ""
-}
-
 func (c *CopyCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.BuildArgs) error {
 	// Resolve from
 	if c.cmd.From != "" {

--- a/pkg/commands/copy.go
+++ b/pkg/commands/copy.go
@@ -38,6 +38,17 @@ type CopyCommand struct {
 	snapshotFiles []string
 }
 
+func (c *CopyCommand) RequiresUnpackedFS() bool {
+	// We want to unpack the root filesystem for copy commands since otherwise
+	// when copying files we may think that the parent directory of the file/dir
+	// being copied doesn't exist, and will then create it with incorrect
+	// permissions based on the file/dir being copied
+	// For example copying a file to /home/username/foo would result in creating
+	// the /home directory with the same permissions as the file foo
+	// and if the file is not world-readable then neither will the /home directory
+    return true
+}
+
 func (c *CopyCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.BuildArgs) error {
 	// Resolve from
 	if c.cmd.From != "" {

--- a/pkg/util/command_util.go
+++ b/pkg/util/command_util.go
@@ -361,6 +361,7 @@ func GetUserFromUsername(userStr string, groupStr string) (string, string, error
 			}
 			gid = group.Gid
 		}
+		gid = groupStr
 	}
 
 	return uid, gid, nil

--- a/pkg/util/command_util.go
+++ b/pkg/util/command_util.go
@@ -350,7 +350,7 @@ func GetUserFromUsername(userStr string, groupStr string) (string, string, error
 	}
 
 	// Same dance with groups
-	gid := ""
+	gid := groupStr
 	if groupStr != "" {
 		_, err := strconv.ParseUint(groupStr, 10, 32)
 		if err != nil {
@@ -361,7 +361,6 @@ func GetUserFromUsername(userStr string, groupStr string) (string, string, error
 			}
 			gid = group.Gid
 		}
-		gid = groupStr
 	}
 
 	return uid, gid, nil

--- a/pkg/util/command_util.go
+++ b/pkg/util/command_util.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/GoogleContainerTools/kaniko/pkg/constants"
@@ -334,40 +335,32 @@ func GetUIDGidFromUserString(commandUserStr string, replacementEnvs []string) (s
 }
 
 func GetUserFromUsername(userStr string, groupStr string) (string, string, error) {
-	// Lookup by username
-	userObj, err := user.Lookup(userStr)
+	// Default to userStr if it is a numeric value like "1000"
+	uid := userStr
+	// Check to see if userStr is numeric ID
+	_, err := strconv.ParseUint(userStr, 10, 32)
 	if err != nil {
-		if _, ok := err.(user.UnknownUserError); ok {
-			// Lookup by id
-			userObj, err = user.LookupId(userStr)
-			if err != nil {
-				return "", "", err
-			}
-		} else {
+		// Was not numeric, try lookup by username
+		userObj, err := user.Lookup(userStr)
+		if err != nil {
+			logrus.Errorf("User string cannot be found and is not numeric %s", userStr)
 			return "", "", err
 		}
+		uid = userObj.Uid
 	}
 
 	// Same dance with groups
-	var group *user.Group
+	gid := ""
 	if groupStr != "" {
-		group, err = user.LookupGroup(groupStr)
+		_, err := strconv.ParseUint(groupStr, 10, 32)
 		if err != nil {
-			if _, ok := err.(user.UnknownGroupError); ok {
-				group, err = user.LookupGroupId(groupStr)
-				if err != nil {
-					return "", "", err
-				}
-			} else {
+			// Was not numeric, try lookup by group name
+			group, err := user.LookupGroup(groupStr)
+			if err != nil {
 				return "", "", err
 			}
+			gid = group.Gid
 		}
-	}
-
-	uid := userObj.Uid
-	gid := ""
-	if group != nil {
-		gid = group.Gid
 	}
 
 	return uid, gid, nil


### PR DESCRIPTION
Change behavior so that a numeric user or group id will just be returned immediately instead of trying to lookup the user id in the operating system.  Performing the lookup would otherwise require that the rootfs has been unpacked and results in errors with cached images.  Will have to change our build templates to use numeric IDs as well (PR will be coming out soon for that)