### PR TITLE
Create parent dirs

### DIFF
--- a/pkg/commands/copy.go
+++ b/pkg/commands/copy.go
@@ -38,17 +38,6 @@ type CopyCommand struct {
 	snapshotFiles []string
 }
 
-func (c *CopyCommand) RequiresUnpackedFS() bool {
-	// We want to unpack the root filesystem for copy commands since otherwise
-	// when copying files we may think that the parent directory of the file/dir
-	// being copied doesn't exist, and will then create it with incorrect
-	// permissions based on the file/dir being copied
-	// For example copying a file to /home/username/foo would result in creating
-	// the /home directory with the same permissions as the file foo
-	// and if the file is not world-readable then neither will the /home directory
-    return true
-}
-
 func (c *CopyCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.BuildArgs) error {
 	// Resolve from
 	if c.cmd.From != "" {

--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -507,8 +507,17 @@ func CopyDir(src, dest, buildcontext string, chownUID, chownGid int) ([]string, 
 		if fi.IsDir() {
 			logrus.Debugf("Creating directory %s", destPath)
 
-			if err := os.MkdirAll(destPath, fi.Mode()); err != nil {
+			// Make any parent directories with 0755 permissions
+			if err := os.MkdirAll(dest, 0755); err != nil {
+				logrus.Infof("error while creating parent directory %s", dest)
 				return nil, err
+			}
+			if !FilepathExists(destPath) {
+				// Make the current directory that is being copied
+				if err := os.Mkdir(destPath, fi.Mode()); err != nil {
+					logrus.Infof("error while creating real directory %s", destPath)
+					return nil, err
+				}
 			}
 			if err := os.Chown(destPath, int(uid), int(gid)); err != nil {
 				return nil, err


### PR DESCRIPTION
Reverting the change to copy.go and instead fixing kaniko so that parent directories get created with 0755 permissions and then the actual directory gets copied over.  This fixes the issue that we were seeing before with the ~/.local directory being inaccessible and also results in saving a bunch of time unpacking filesystem layers at buildtime :sunglasses:.   